### PR TITLE
use real thread-local storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.1.0"
 dependencies = [
@@ -786,6 +796,7 @@ dependencies = [
  "sha2",
  "test-case",
  "thiserror",
+ "thread_local",
  "tiktoken-rs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "0.21.0"
 thiserror = "1.0.38"
 const-primes = "0.8.7"
 odht = "0.3.1"
+thread_local = "1.1.8"
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
upstream code in openai/tiktoken is wrapped with PyO3 so they're concerned about short-lived python-land threads eating up memory

in our case, we have a fixed actor-thread-pool dedicated to tokenization so we don't need extra copies and hash collisions getting in the way
